### PR TITLE
Downgrade eslint

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -4,5 +4,6 @@ coverage
 npm-debug.log
 .dockerignore
 .editorconfig
+.jscsrc
 .npmignore
 .travis.yml

--- a/package.json
+++ b/package.json
@@ -62,7 +62,7 @@
     "chai-as-promised": "^5.3.0",
     "chimp": "^0.39.3",
     "debug": "^2.2.0",
-    "eslint": "^3.2.2",
+    "eslint": "^2.13.1",
     "istanbul": "^0.4.4",
     "jscs": "^3.0.6",
     "mocha": "^2.2.5",


### PR DESCRIPTION
Downgrades eslint to ensure compatibility with HOF. Also re-adds
.jscsrc to the .gitignore as it will be added npm install.
